### PR TITLE
KC v25 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@
 # Maven #
 #########
 target
+
+# VSCode #
+##########
+.vscode

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.keycloak</groupId>
     <artifactId>keycloak-orcid</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
 
     <name>${project.artifactId}</name>
     <description>ORCID as Social Provider in Keycloak</description>
@@ -11,7 +11,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <keycloak.version>22.0.3</keycloak.version>
+        <keycloak.version>25.0.6</keycloak.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/org/keycloak/social/orcid/OrcidIdentityProvider.java
+++ b/src/main/java/org/keycloak/social/orcid/OrcidIdentityProvider.java
@@ -43,7 +43,7 @@ public class OrcidIdentityProvider extends AbstractOAuth2IdentityProvider<OrcidI
 
         String id = getJsonProperty(orcidIdentifier, "path");
 
-        BrokeredIdentityContext user = new BrokeredIdentityContext(id);
+        BrokeredIdentityContext user = new BrokeredIdentityContext(id, getConfig());
         user.setUsername(id);
         JsonNode name = person.get("name");
         if (name!= null && ! name.isNull()) {
@@ -65,7 +65,6 @@ public class OrcidIdentityProvider extends AbstractOAuth2IdentityProvider<OrcidI
         }
         user.setEmail(email);
 
-        user.setIdpConfig(getConfig());
         user.setIdp(this);
 
         AbstractJsonUserAttributeMapper.storeUserProfileForMapper(user, node, getConfig().getAlias());


### PR DESCRIPTION
Moved idpConfig() to BrokeredIdentityContext constructor. The constructor changed from [v24](https://www.keycloak.org/docs-api/24.0.3/javadocs/org/keycloak/broker/provider/BrokeredIdentityContext.html) to [v25](https://www.keycloak.org/docs-api/25.0.6/javadocs/org/keycloak/broker/provider/BrokeredIdentityContext.html).